### PR TITLE
Handle missing requests dependency for tests

### DIFF
--- a/tests/test_wb_client.py
+++ b/tests/test_wb_client.py
@@ -1,0 +1,214 @@
+import math
+import re
+from typing import Any
+
+import pytest
+
+import wb_client
+
+from requests import HTTPError
+
+
+class DummyResponse:
+    def __init__(self, json_data: Any, status_code: int = 200, url: str = "http://example") -> None:
+        self._json_data = json_data
+        self.status_code = status_code
+        self.url = url
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise HTTPError(f"HTTP {self.status_code}")
+
+    def json(self) -> Any:
+        return self._json_data
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (258368289, 258368289),
+        ("258368289", 258368289),
+        ("https://example.com/catalog/258368289/detail", 258368289),
+        ("no digits", None),
+        (0, None),
+        (-1, None),
+    ],
+)
+def test_extract_nm(value: object, expected: int | None) -> None:
+    assert wb_client.extract_nm(value) == expected
+
+
+def test_get_card_api_calls_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_request(url: str, *, params: dict[str, Any] | None = None, timeout: int) -> dict[str, Any]:
+        captured["url"] = url
+        captured["params"] = params
+        captured["timeout"] = timeout
+        return {"status": "ok"}
+
+    monkeypatch.setattr(wb_client, "_request_with_retries", fake_request)
+    result = wb_client.get_card_api("258368289")
+
+    assert result == {"status": "ok"}
+    assert captured["url"] == wb_client.CARD_API_URL
+    assert captured["params"] == {**wb_client.CARD_API_PARAMS, "nm": 258368289}
+    assert captured["timeout"] == wb_client.DEFAULT_TIMEOUT
+
+
+def test_get_card_api_invalid_nm(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = False
+
+    def fake_request(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        nonlocal called
+        called = True
+        return {"unexpected": True}
+
+    monkeypatch.setattr(wb_client, "_request_with_retries", fake_request)
+    result = wb_client.get_card_api("bad value")
+
+    assert result == {}
+    assert not called
+
+
+def test_get_info_card_json_attempts_hosts(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def fake_single(url: str, *, params: dict[str, Any] | None = None, timeout: int) -> dict[str, Any] | None:
+        calls.append(url)
+        if len(calls) == 2:
+            return {"payload": True}
+        return None
+
+    monkeypatch.setattr(wb_client, "_single_request", fake_single)
+    result = wb_client.get_info_card_json(123456789)
+
+    assert result == {"payload": True}
+    assert calls[0].startswith("http://basket-")
+
+    expected_hosts = wb_client._guess_basket_hosts(123456789 // 100000)
+    called_hosts: list[int] = []
+    for url in calls:
+        match = re.search(r"basket-(\d+)", url)
+        if match:
+            called_hosts.append(int(match.group(1)))
+
+    assert called_hosts == expected_hosts[: len(called_hosts)]
+
+
+def test_get_info_card_json_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wb_client, "_single_request", lambda *args, **kwargs: None)
+    result = wb_client.get_info_card_json("bad")
+    assert result == {}
+
+
+def test_get_content_v2_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    def fake_single(url: str, *, params: dict[str, Any] | None = None, timeout: int) -> dict[str, Any] | None:
+        calls.append((url, params))
+        if len(calls) == 3:
+            return {"content": True}
+        return None
+
+    monkeypatch.setattr(wb_client, "_single_request", fake_single)
+    result = wb_client.get_content_v2(321)
+
+    assert result == {"content": True}
+    assert all(params == {"nm": 321} for _, params in calls)
+
+
+def test_get_content_v2_invalid_nm(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = False
+
+    def fake_single(*args: Any, **kwargs: Any) -> dict[str, Any] | None:
+        nonlocal called
+        called = True
+        return None
+
+    monkeypatch.setattr(wb_client, "_single_request", fake_single)
+    result = wb_client.get_content_v2("oops")
+
+    assert result == {}
+    assert not called
+
+
+def test_single_request_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = DummyResponse({"ok": True})
+
+    def fake_get(url: str, *, params: dict[str, Any] | None = None, headers: dict[str, str] | None = None, timeout: int) -> DummyResponse:
+        return response
+
+    monkeypatch.setattr(wb_client.requests, "get", fake_get)
+    result = wb_client._single_request("http://example.com")
+    assert result == {"ok": True}
+
+
+def test_single_request_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = DummyResponse({"ok": False}, status_code=500)
+
+    def fake_get(url: str, *, params: dict[str, Any] | None = None, headers: dict[str, str] | None = None, timeout: int) -> DummyResponse:
+        return response
+
+    monkeypatch.setattr(wb_client.requests, "get", fake_get)
+    result = wb_client._single_request("http://example.com")
+    assert result is None
+
+
+def test_single_request_bad_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    class BadJsonResponse(DummyResponse):
+        def json(self) -> Any:
+            raise ValueError("bad json")
+
+    response = BadJsonResponse({"ignored": True})
+
+    def fake_get(url: str, *, params: dict[str, Any] | None = None, headers: dict[str, str] | None = None, timeout: int) -> DummyResponse:
+        return response
+
+    monkeypatch.setattr(wb_client.requests, "get", fake_get)
+    result = wb_client._single_request("http://example.com")
+    assert result is None
+
+
+def test_request_with_retries_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts: list[int] = []
+
+    def fake_single(url: str, *, params: dict[str, Any] | None = None, timeout: int) -> dict[str, Any] | None:
+        attempts.append(1)
+        if len(attempts) == 3:
+            return {"ok": True}
+        return None
+
+    monkeypatch.setattr(wb_client, "_single_request", fake_single)
+    result = wb_client._request_with_retries("http://example.com")
+
+    assert result == {"ok": True}
+    assert len(attempts) == 3
+
+
+def test_request_with_retries_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wb_client, "_single_request", lambda *args, **kwargs: None)
+    result = wb_client._request_with_retries("http://example.com")
+    assert result == {}
+
+
+def test_guess_basket_hosts_negative() -> None:
+    assert wb_client._guess_basket_hosts(-1) == [9, 1, 2]
+
+
+def test_guess_basket_hosts_positive() -> None:
+    hosts = wb_client._guess_basket_hosts(320)
+    assert hosts == [2, 1, 3, 4]
+
+
+def test_sleep_with_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: list[float] = []
+
+    monkeypatch.setattr(wb_client.time, "sleep", lambda value: recorded.append(value))
+    monkeypatch.setattr(wb_client.random, "uniform", lambda a, b: 0.0)
+
+    wb_client._sleep_with_backoff(3)
+
+    expected = wb_client.BACKOFF_FACTOR * (2 ** (3 - 1))
+    assert len(recorded) == 1
+    assert math.isclose(recorded[0], expected)

--- a/tests/test_wb_parser.py
+++ b/tests/test_wb_parser.py
@@ -1,0 +1,188 @@
+from typing import Any
+
+import pytest
+
+import wb_parser
+from wb_parser import (
+    ProductRaw,
+    _ensure_mapping,
+    _extract_description_from_basket,
+    _extract_description_from_content,
+    _extract_int,
+    _extract_primary_product,
+    _find_first_string,
+    _normalize_string,
+    collect_product_records,
+    fetch_product_raw,
+)
+
+
+def test_product_raw_to_dict() -> None:
+    product = ProductRaw(
+        id=1,
+        name="Name",
+        brand="Brand",
+        supplier="Supplier",
+        description="Description",
+        sources={"card_api": {"id": 1}},
+    )
+
+    result = product.to_dict()
+
+    assert result == {
+        "id": 1,
+        "name": "Name",
+        "brand": "Brand",
+        "supplier": "Supplier",
+        "description": "Description",
+        "sources": {"card_api": {"id": 1}},
+    }
+
+
+def test_ensure_mapping() -> None:
+    original = {"key": "value"}
+    result = _ensure_mapping(original)
+
+    assert result == original
+    assert result is not original
+    assert _ensure_mapping(None) == {}
+
+
+def test_extract_primary_product_success() -> None:
+    data = {"data": {"products": [{"id": 1}, {"id": 2}]}}
+    product = _extract_primary_product(data)
+    assert product == {"id": 1}
+
+
+def test_extract_primary_product_missing() -> None:
+    data: dict[str, Any] = {"data": {"items": []}}
+    assert _extract_primary_product(data) is None
+
+
+def test_extract_int() -> None:
+    mapping = {"value": "10"}
+    assert _extract_int(mapping, "value") == 10
+    assert _extract_int(mapping, "missing") is None
+    assert _extract_int({"value": "bad"}, "value") is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("  spaced  ", "spaced"),
+        ("", None),
+        (None, None),
+        (123, "123"),
+    ],
+)
+def test_normalize_string(value: Any, expected: str | None) -> None:
+    assert _normalize_string(value) == expected
+
+
+def test_find_first_string_mapping() -> None:
+    data = {"a": {"b": "value"}}
+    assert _find_first_string(data, ("b",)) == "value"
+
+
+def test_find_first_string_sequence() -> None:
+    data = [1, {"nested": [{"target": "found"}]}]
+    assert _find_first_string(data, ("target",)) == "found"
+
+
+def test_extract_description_from_basket() -> None:
+    data = {"info": {"description": "desc"}}
+    assert _extract_description_from_basket(data) == "desc"
+
+
+def test_extract_description_from_content_variants() -> None:
+    direct = {"description": "Direct"}
+    assert _extract_description_from_content(direct) == "Direct"
+
+    nested = {"data": {"products": [{"descriptionText": "Nested"}]}}
+    assert _extract_description_from_content(nested) == "Nested"
+
+    fallback = {"data": {"details": {"text": "Fallback"}}}
+    assert _extract_description_from_content(fallback) == "Fallback"
+
+
+def test_fetch_product_raw_prefers_info_card(monkeypatch: pytest.MonkeyPatch) -> None:
+    card_payload = {"data": {"products": [{"id": 100, "name": "Item", "brand": "Brand", "supplier": "Supplier"}]}}
+    info_payload = {"description": "From info"}
+
+    monkeypatch.setattr(wb_parser, "get_card_api", lambda nm: card_payload)
+    monkeypatch.setattr(wb_parser, "get_info_card_json", lambda nm: info_payload)
+    monkeypatch.setattr(wb_parser, "get_content_v2", lambda nm: (_ for _ in ()).throw(AssertionError("should not call")))
+
+    product = fetch_product_raw("http://example.com/item/100")
+
+    assert product.id == 100
+    assert product.name == "Item"
+    assert product.brand == "Brand"
+    assert product.supplier == "Supplier"
+    assert product.description == "From info"
+    assert product.sources["card_api"] == card_payload
+    assert product.sources["info_card_json"] == info_payload
+    assert product.sources["content_v2"] == {}
+
+
+def test_fetch_product_raw_uses_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    card_payload = {"data": {"products": [{"id": 101, "name": "Item2", "brand": "Brand2", "supplier": "Supplier2"}]}}
+    info_payload: dict[str, Any] = {}
+    content_payload = {"data": {"products": [{"description_html": "<p>HTML</p>"}]}}
+
+    monkeypatch.setattr(wb_parser, "get_card_api", lambda nm: card_payload)
+    monkeypatch.setattr(wb_parser, "get_info_card_json", lambda nm: info_payload)
+    monkeypatch.setattr(wb_parser, "get_content_v2", lambda nm: content_payload)
+
+    product = fetch_product_raw(101)
+
+    assert product.id == 101
+    assert product.description == "<p>HTML</p>"
+    assert product.sources["content_v2"] == content_payload
+
+
+def test_fetch_product_raw_handles_missing_primary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wb_parser, "get_card_api", lambda nm: {"unexpected": []})
+    monkeypatch.setattr(wb_parser, "get_info_card_json", lambda nm: {})
+    monkeypatch.setattr(wb_parser, "get_content_v2", lambda nm: {})
+
+    product = fetch_product_raw("999")
+
+    assert product.id == 999
+    assert product.name is None
+    assert product.description is None
+
+
+def test_collect_product_records(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_fetch(nm: object) -> ProductRaw:
+        return ProductRaw(
+            id=int(wb_parser.extract_nm(nm) or 0),
+            name="Name",
+            brand="Brand",
+            supplier="Supplier",
+            description="Desc",
+            sources={},
+        )
+
+    monkeypatch.setattr(wb_parser, "fetch_product_raw", fake_fetch)
+
+    records = collect_product_records([1, "2"])
+
+    assert records == [
+        {
+            "id": 1,
+            "name": "Name",
+            "brand": "Brand",
+            "supplier": "Supplier",
+            "description": "Desc",
+            "sources": {},
+        },
+        {
+            "id": 2,
+            "name": "Name",
+            "brand": "Brand",
+            "supplier": "Supplier",
+            "description": "Desc",
+            "sources": {},
+        },
+    ]


### PR DESCRIPTION
## Summary
- add a lightweight fallback shim for the `requests` import so the client module still loads when the dependency is absent
- adjust the client tests to import the module before requesting `HTTPError`, ensuring the shim is registered when running in minimal environments

## Testing
- python -m pytest
- python -m compileall wb_client.py wb_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68d3c41ec56483258a526afd71c7b151