### PR TITLE
Improve basket host selection

### DIFF
--- a/tests/test_wb_client.py
+++ b/tests/test_wb_client.py
@@ -198,7 +198,26 @@ def test_guess_basket_hosts_negative() -> None:
 
 def test_guess_basket_hosts_positive() -> None:
     hosts = wb_client._guess_basket_hosts(320)
-    assert hosts == [2, 1, 3, 4]
+    assert hosts == [3, 2, 1, 4]
+
+
+@pytest.mark.parametrize(
+    ("vol", "expected"),
+    [
+        (0, 1),
+        (144, 2),
+        (320, 3),
+        (720, 5),
+        (1116, 8),
+        (5000, 27),
+        (6126, 31),
+        (7000, wb_client.MAX_BASKET_HOST),
+    ],
+)
+def test_guess_basket_hosts_primary_mapping(vol: int, expected: int) -> None:
+    hosts = wb_client._guess_basket_hosts(vol)
+    assert hosts
+    assert hosts[0] == expected
 
 
 def test_sleep_with_backoff(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- use the Wildberries threshold table to resolve basket hosts before falling back to the legacy neighbour scan
- extend the basket host tests to cover the new mapping and adjust expectations

## Testing
- `PYTHONPATH=etl/parser pytest`
- `python -m compileall etl/parser/wb_client.py etl/parser/wb_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68d3e70173d48325b2b22ef3a33a3f80